### PR TITLE
fix 'group libvirtd does not exist' bug

### DIFF
--- a/src/vagrant/setup_vagrant.sh
+++ b/src/vagrant/setup_vagrant.sh
@@ -43,6 +43,7 @@ EOF
     sudo apt-get install -y bridge-utils qemu libvirt-bin ebtables dnsmasq
     sudo apt-get install -y libxslt-dev libxml2-dev libvirt-dev zlib1g-dev ruby-dev
     vagrant plugin install vagrant-libvirt
+    sudo addgroup libvirtd
     sudo adduser ${USER} libvirtd
     sudo service libvirtd restart
 }


### PR DESCRIPTION
It shows the bug as follows when I use setup_vagrant.sh to setup my host.
```
-----------------
Setting up libicu-dev (57.1-6ubuntu0.2) ...
Setting up libxml2-dev:amd64 (2.9.4+dfsg1-4ubuntu1.2) ...
Setting up libxslt1-dev:amd64 (1.1.29-2.1ubuntu1) ...
+ vagrant plugin install vagrant-libvirt
Installing the 'vagrant-libvirt' plugin. This can take a few minutes...
Installed the plugin 'vagrant-libvirt (0.0.40)'!
+ sudo adduser wg libvirtd
adduser: The group `libvirtd' does not exist.
-----------------
```

**My host info:**
Distributor ID: Ubuntu
Description:    Ubuntu 17.10
Release:        17.10
Codename:       artful
Linux wgwks 4.10.17-041017-generic #201705201051 SMP Sat May 20 14:53:33 UTC 2017 x86_64 x86_64 x86_64 GNU/Linux

